### PR TITLE
CVE-2023-22115

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:sha256:fe036967257bf11aab7184e371920c5b629f0dd36cbefdf4ccd2ae18cc900dbd
+FROM mysql:8.0.34
 
 ENV MYSQL_DATABASE=cities \
     MYSQL_USER=shipping \

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0.34
+FROM mysql:8.0.45
 
 ENV MYSQL_DATABASE=cities \
     MYSQL_USER=shipping \


### PR DESCRIPTION
Cve-2023-22115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated Docker base-image bump; main risk is runtime/compatibility changes from the newer MySQL version.
> 
> **Overview**
> Updates `mysql/Dockerfile` to use the `mysql:8.0.45` base image instead of a pinned sha256 digest, aligning the container with a newer MySQL release (referenced by CVE-2023-22115).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c0bda09392cc204325337f120944a9d20ec6ed0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->